### PR TITLE
Use `pathlibfs` for scheme-agnostic file access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Use `pathlibfs` for scheme-agnostic source access
 
 ## 2023-10-07 0.1.0
 - Add example data files in different formats

--- a/hubspot_tech_writing/core.py
+++ b/hubspot_tech_writing/core.py
@@ -14,7 +14,7 @@ from hubspot_tech_writing.html import postprocess
 from hubspot_tech_writing.hubspot_api import HubSpotAdapter, HubSpotBlogPost, HubSpotFile
 from hubspot_tech_writing.util.common import ContentTypeResolver
 from hubspot_tech_writing.util.html import HTMLImageTranslator
-from hubspot_tech_writing.util.io import path_from_url, to_io
+from hubspot_tech_writing.util.io import open_url, to_io
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def upload(
 ):
     source_path: Path
     if isinstance(source, str):
-        source_path = path_from_url(source)
+        source_path = open_url(source)
     else:
         source_path = source
     logger.info(f"Source: {source_path}")

--- a/hubspot_tech_writing/core.py
+++ b/hubspot_tech_writing/core.py
@@ -14,7 +14,7 @@ from hubspot_tech_writing.html import postprocess
 from hubspot_tech_writing.hubspot_api import HubSpotAdapter, HubSpotBlogPost, HubSpotFile
 from hubspot_tech_writing.util.common import ContentTypeResolver
 from hubspot_tech_writing.util.html import HTMLImageTranslator
-from hubspot_tech_writing.util.io import to_io
+from hubspot_tech_writing.util.io import path_from_url, to_io
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +75,14 @@ def upload(
     folder_id: t.Optional[str] = None,
     folder_path: t.Optional[str] = None,
 ):
-    source_path = Path(source)
+    source_path: Path
+    if isinstance(source, str):
+        source_path = path_from_url(source)
+    else:
+        source_path = source
+    logger.info(f"Source: {source_path}")
 
-    ctr = ContentTypeResolver(name=source_path)
+    ctr = ContentTypeResolver(filepath=source_path)
 
     logger.info(f"Uploading file: {source}")
     hsa = HubSpotAdapter(access_token=access_token)
@@ -101,6 +106,7 @@ def upload(
             )
             hit = HTMLImageTranslator(html=html, source_path=source_path, uploader=uploader)
             hit.discover().process()
+            logger.debug(hit)
             html = hit.html_out
 
         # Upload blog post.

--- a/hubspot_tech_writing/util/common.py
+++ b/hubspot_tech_writing/util/common.py
@@ -1,9 +1,10 @@
 import logging
 import typing as t
-from pathlib import Path
 
 import colorlog
 from colorlog.escape_codes import escape_codes
+from pathlibfs import Path
+from yarl import URL
 
 
 def setup_logging(level=logging.INFO, verbose: bool = False):
@@ -23,9 +24,12 @@ class ContentTypeResolver:
     HTML_SUFFIXES = [".html", ".html5", ".htm"]
     TEXT_SUFFIXES = MARKUP_SUFFIXES + HTML_SUFFIXES + [".txt"]
 
-    def __init__(self, name: t.Union[str, Path]):
-        self.name = name
-        self.suffix = Path(name).suffix
+    def __init__(self, filepath: t.Union[str, Path]):
+        self.url = URL(str(filepath))
+        if self.url.is_absolute():
+            self.url = self.url.with_scheme("")
+        self.path = Path(str(self.url))
+        self.suffix = self.path.suffix
 
     def is_markup(self):
         return self.suffix in self.MARKUP_SUFFIXES
@@ -38,3 +42,8 @@ class ContentTypeResolver:
 
     def is_file(self):
         return not self.is_text()
+
+
+def url_to_path(filepath: str):
+    url = URL(str(filepath)).with_scheme("")
+    return Path(str(url))

--- a/hubspot_tech_writing/util/common.py
+++ b/hubspot_tech_writing/util/common.py
@@ -4,7 +4,8 @@ import typing as t
 import colorlog
 from colorlog.escape_codes import escape_codes
 from pathlibfs import Path
-from yarl import URL
+
+from hubspot_tech_writing.util.io import path_without_scheme
 
 
 def setup_logging(level=logging.INFO, verbose: bool = False):
@@ -25,10 +26,7 @@ class ContentTypeResolver:
     TEXT_SUFFIXES = MARKUP_SUFFIXES + HTML_SUFFIXES + [".txt"]
 
     def __init__(self, filepath: t.Union[str, Path]):
-        self.url = URL(str(filepath))
-        if self.url.is_absolute():
-            self.url = self.url.with_scheme("")
-        self.path = Path(str(self.url))
+        self.path = path_without_scheme(filepath)
         self.suffix = self.path.suffix
 
     def is_markup(self):
@@ -42,8 +40,3 @@ class ContentTypeResolver:
 
     def is_file(self):
         return not self.is_text()
-
-
-def url_to_path(filepath: str):
-    url = URL(str(filepath)).with_scheme("")
-    return Path(str(url))

--- a/hubspot_tech_writing/util/html.py
+++ b/hubspot_tech_writing/util/html.py
@@ -2,9 +2,10 @@ import dataclasses
 import logging
 import typing as t
 from copy import deepcopy
-from pathlib import Path
+from pprint import pformat
 
 from bs4 import BeautifulSoup
+from pathlibfs import Path
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class HTMLImage:
     alt: str
-    src: str
+    src: Path
 
 
 class HTMLImageTranslator:
@@ -21,19 +22,18 @@ class HTMLImageTranslator:
     After that, replace URLs in HTML document.
     """
 
-    def __init__(self, html: str, source_path: t.Union[str, Path], uploader: t.Optional[t.Callable] = None):
+    def __init__(self, html: str, source_path: Path, uploader: t.Optional[t.Callable] = None):
         self.html_in: str = html
         self.html_out: t.Optional[str] = None
-        self.source_path = source_path
+        self.source = source_path
         self.uploader = uploader
         self.images_in: t.List[HTMLImage] = []
         self.images_local: t.List[HTMLImage] = []
         self.images_remote: t.List[HTMLImage] = []
 
     def __str__(self):
-        return (
-            f"HTMLImageTranslator:\nin:     {self.images_in}\nlocal:  {self.images_local}\nremote: {self.images_remote}"
-        )
+        info = {"source": self.source, "in": self.images_in, "local": self.images_local, "remote": self.images_remote}
+        return f"HTMLImageTranslator:\n{pformat(info)}"
 
     def discover(self):
         self.scan().resolve()
@@ -59,9 +59,10 @@ class HTMLImageTranslator:
         """
         Process discovered image elements, computing effective paths.
         """
-        if self.source_path is None:
+        if self.source is None:
+            logger.warning("No resolving without source path")
             return self
-        parent_path = Path(self.source_path)
+        parent_path = self.source
         if parent_path.is_file():
             parent_path = parent_path.parent
         self.images_local = []
@@ -74,7 +75,7 @@ class HTMLImageTranslator:
 
                 # Relative paths are relative to the original document.
                 else:
-                    image_new.src = str(Path(parent_path) / image.src)
+                    image_new.src = parent_path / image.src
             self.images_local.append(image_new)
         return self
 
@@ -86,7 +87,7 @@ class HTMLImageTranslator:
             logger.warning("No upload without uploader")
             return self
         for image_local in self.images_local:
-            hs_file = self.uploader(source=image_local.src, name=Path(image_local.src).name)
+            hs_file = self.uploader(source=image_local.src, name=image_local.src.name)
             image_url = hs_file.url
             image_remote: HTMLImage = deepcopy(image_local)
             image_remote.src = image_url

--- a/hubspot_tech_writing/util/html.py
+++ b/hubspot_tech_writing/util/html.py
@@ -88,9 +88,8 @@ class HTMLImageTranslator:
             return self
         for image_local in self.images_local:
             hs_file = self.uploader(source=image_local.src, name=image_local.src.name)
-            image_url = hs_file.url
             image_remote: HTMLImage = deepcopy(image_local)
-            image_remote.src = image_url
+            image_remote.src = hs_file.url
             self.images_remote.append(image_remote)
         return self
 

--- a/hubspot_tech_writing/util/io.py
+++ b/hubspot_tech_writing/util/io.py
@@ -3,20 +3,63 @@ import io
 import typing as t
 from pathlib import Path
 
-import requests
+from pathlibfs import Path as PathPlus
+from yarl import URL
 
 
 @contextlib.contextmanager
 def to_io(source: t.Union[str, Path, t.IO]) -> t.Generator[t.IO, None, None]:
-    if isinstance(source, (str, Path)):
+    fp: t.IO
+    if isinstance(source, io.TextIOWrapper):
+        fp = source
+    elif isinstance(source, (str, Path, PathPlus)):
         source = str(source)
-        fp: t.IO
+        path = path_from_url(source)
+        fp = path.open(mode="rt")
+        """
         if source.startswith("http://") or source.startswith("https://"):
             response = requests.get(source, timeout=10.0)
             fp = io.StringIO(response.text)
         else:
             fp = open(source, "r")
+        """
     else:
-        fp = source
+        raise TypeError(f"Unable to converge to IO handle. type={type(source)}, value={source}")
     yield fp
     fp.close()
+
+
+def path_from_url(url: str) -> PathPlus:
+    """
+    Convert GitHub HTTP URL to pathlibfs / fsspec URL.
+
+    Input URLs
+    ----------
+    github+https://foobar:ghp_lalala@github.com/acme/sweet-camino/path/to/document.md
+    github+https://foobar:ghp_lalala@github.com/acme/sweet-camino/blob/main/path/to/document.md
+
+    Output Path
+    -----------
+    fs = Path("github://path/to/document.md", username="foobar", token="ghp_lalala", org="acme", repo="sweet-camino")
+    """
+    uri = URL(url)
+
+    if uri.scheme.startswith("github+https"):
+        path_fragments = uri.path.split("/")[1:]
+        path_kwargs = {
+            "username": uri.user,
+            "token": uri.password,
+            "org": path_fragments[0],
+            "repo": path_fragments[1],
+        }
+
+        real_path_fragments = path_fragments[2:]
+        if path_fragments[2] == "blob":
+            real_path_fragments = path_fragments[4:]
+
+        downstream_url = "github://" + "/".join(real_path_fragments)
+        path = PathPlus(downstream_url, **path_kwargs)
+
+    else:
+        path = PathPlus(url)
+    return path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ dependencies = [
   "hubspot-api-client<9",
   "markdown<4",
   "mkdocs-linkcheck<2",
+  "pathlibfs<0.6",
   "requests<3",
+  "yarl<2",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,30 @@ def markdownfile() -> Path:
     return Path(__file__).parent / "data" / "hubspot-blog-post-original.md"
 
 
+def get_markdownurl(infix: str = "", scheme: str = "https:") -> str:
+    return f"{scheme}//github.com/crate-workbench/hubspot-tech-writing/{infix}tests/data/hubspot-blog-post-original.md"
+
+
+@pytest.fixture
+def markdownurl_https_raw() -> str:
+    return get_markdownurl(infix="raw/main/")
+
+
+@pytest.fixture
+def markdownurl_github_https_bare() -> str:
+    return get_markdownurl(scheme="github+https:")
+
+
+@pytest.fixture
+def markdownurl_github_https_raw() -> str:
+    return get_markdownurl(infix="raw/main/", scheme="github+https:")
+
+
+@pytest.fixture
+def markdownurl_github_https_blob() -> str:
+    return get_markdownurl(infix="blob/main/", scheme="github+https:")
+
+
 @pytest.fixture
 def markdownfile_minimal_broken_links() -> Path:
     return Path(__file__).parent / "data" / "minimal-broken-links.md"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,9 +13,8 @@ def test_convert_file(markdownfile):
     check_content(html)
 
 
-def test_convert_url():
-    url = "https://github.com/crate-workbench/hubspot-tech-writing/raw/main/tests/data/hubspot-blog-post-original.md"
-    html = convert(url)
+def test_convert_url(markdownurl_https_raw):
+    html = convert(markdownurl_https_raw)
     check_content(html)
 
 

--- a/tests/test_hubspot_blogpost.py
+++ b/tests/test_hubspot_blogpost.py
@@ -1,19 +1,25 @@
-import json
 import os
 
 import pytest
-from hubspot.cms.blogs.blog_posts.rest import RESTResponse
-from urllib3 import HTTPResponse
 
 from hubspot_tech_writing.core import delete_blogpost, upload
-
-
-def mkresponse(data, status=200, reason="OK"):
-    body = json.dumps(data).encode("utf-8")
-    return RESTResponse(HTTPResponse(body=body, status=status, reason=reason))
+from tests.test_hubspot_file import response_simulator_upload
+from tests.util import mkresponse
 
 
 def response_simulator_create(self, method, url, **kwargs):
+    if method == "GET" and url == "https://api.hubapi.com/cms/v3/blogs/posts":
+        response = mkresponse({"total": 0, "results": []})
+    elif method == "POST" and url == "https://api.hubapi.com/cms/v3/blogs/posts":
+        response = mkresponse({"id": "12345"}, status=201, reason="Created")
+    elif method == "PATCH" and url == "https://api.hubapi.com/cms/v3/blogs/posts/12345":
+        response = mkresponse({"id": "12345"})
+    else:
+        raise ValueError(f"No HTTP conversation mock for: method={method}, url={url}")
+    return response
+
+
+def response_simulator_create_with_image(self, method, url, **kwargs):
     if method == "GET" and url == "https://api.hubapi.com/cms/v3/blogs/posts":
         response = mkresponse({"total": 0, "results": []})
     elif method == "POST" and url == "https://api.hubapi.com/cms/v3/blogs/posts":
@@ -93,7 +99,7 @@ def test_upload_blogpost_create_from_markdown(hubspot_access_token, mocker, capl
 
 
 def test_upload_blogpost_update(hubspot_access_token, mocker, caplog, tmp_path):
-    tmpfile = tmp_path / "foo.html"
+    tmpfile = tmp_path / "foo.md"
     tmpfile.write_text("# Foobar\nFranz jagt im komplett verwahrlosten Taxi quer durch Bayern.")
 
     mocker.patch("hubspot.cms.blogs.blog_posts.rest.RESTClientObject.request", response_simulator_update)
@@ -105,6 +111,35 @@ def test_upload_blogpost_update(hubspot_access_token, mocker, caplog, tmp_path):
     )
 
     assert "Uploading file:" in caplog.text
+    assert "Loading blog post: HubSpotBlogPost identifier=None, name=hstw-test" in caplog.text
+    assert "Saving blog post: HubSpotBlogPost identifier=12345, name=hstw-test" in caplog.text
+
+
+def test_upload_blogpost_with_image(hubspot_access_token, mocker, caplog, tmp_path):
+    mdfile = tmp_path / "foo.md"
+    pngfile = tmp_path / "images" / "bar.png"
+    pngfile.parent.mkdir()
+    mdfile.write_text("![bar](images/bar.png)")
+    pngfile.write_bytes(b"")
+
+    mocker.patch("hubspot.cms.blogs.blog_posts.rest.RESTClientObject.request", response_simulator_create_with_image)
+    mocker.patch("hubspot.files.files.rest.RESTClientObject.request", response_simulator_upload)
+    upload(
+        source=mdfile,
+        name="hstw-test",
+        content_group_id="55844199082",
+        folder_path="/path/to/assets",
+        access_token=hubspot_access_token,
+    )
+
+    assert "Uploading file:" in caplog.text
+
+    assert "Loading file: HubSpotFile identifier=None, name=bar.png, folder=/path/to/assets" in caplog.text
+    assert "Searching for 'bar.png' in folder path '/path/to/assets'" in caplog.text
+    assert "File does not exist: bar.png" in caplog.text
+    assert "Creating: HubSpotFile identifier=None, name=bar.png, folder=/path/to/assets" in caplog.text
+    assert "Saving file: HubSpotFile identifier=12345, name=bar.png, folder=/path/to/assets" in caplog.text
+
     assert "Loading blog post: HubSpotBlogPost identifier=None, name=hstw-test" in caplog.text
     assert "Saving blog post: HubSpotBlogPost identifier=12345, name=hstw-test" in caplog.text
 

--- a/tests/test_hubspot_file.py
+++ b/tests/test_hubspot_file.py
@@ -5,16 +5,18 @@ import pytest
 
 from hubspot_tech_writing.core import delete_file, upload
 
-from .test_hubspot_blogpost import mkresponse
+from .util import mkresponse
 
 
 def response_simulator_upload(self, method, url, **kwargs):
     if method == "GET" and url == "https://api.hubapi.com/files/v3/files/search":
         response = mkresponse({"total": 0, "results": []})
     elif method == "POST" and url == "https://api.hubapi.com/files/v3/files":
-        response = mkresponse({"id": "12345"}, status=201, reason="Created")
+        response = mkresponse(
+            {"id": "12345", "url": "https://site.example/hubfs/any.png"}, status=201, reason="Created"
+        )
     elif method == "PUT" and url == "https://api.hubapi.com/files/v3/files/12345":
-        response = mkresponse({"id": "12345"})
+        response = mkresponse({"id": "12345", "url": "https://site.example/hubfs/any.png"})
     else:
         raise ValueError(f"No HTTP conversation mock for: method={method}, url={url}")
     return response

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,80 @@
+from hubspot_tech_writing.util.common import ContentTypeResolver
+from hubspot_tech_writing.util.io import open_url, path_without_scheme
+
+
+def test_content_type_resolver_local_html():
+    ctr = ContentTypeResolver("/path/to/document.html")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is False
+    assert ctr.is_html() is True
+    assert ctr.suffix == ".html"
+
+
+def test_content_type_resolver_local_markdown():
+    ctr = ContentTypeResolver("/path/to/document.md")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is True
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".md"
+
+
+def test_content_type_resolver_local_text():
+    ctr = ContentTypeResolver("/path/to/document.txt")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is False
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".txt"
+
+
+def test_content_type_resolver_local_image():
+    ctr = ContentTypeResolver("/path/to/document.png")
+    assert ctr.is_file() is True
+    assert ctr.is_text() is False
+    assert ctr.is_markup() is False
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".png"
+
+
+def test_content_type_resolver_remote_https():
+    ctr = ContentTypeResolver("https://site.example/path/to/document.md")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is True
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".md"
+
+
+def test_content_type_resolver_remote_github():
+    ctr = ContentTypeResolver("github://site.example/path/to/document.md")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is True
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".md"
+
+
+def test_content_type_resolver_remote_github_https():
+    ctr = ContentTypeResolver("github+https://site.example/path/to/document.md")
+    assert ctr.is_file() is False
+    assert ctr.is_text() is True
+    assert ctr.is_markup() is True
+    assert ctr.is_html() is False
+    assert ctr.suffix == ".md"
+
+
+def test_path_without_scheme_local():
+    assert str(path_without_scheme("/path/to/document.md")) == "/path/to/document.md"
+
+
+def test_path_without_scheme_url():
+    assert str(path_without_scheme("https://site.example/path/to/document.md")) == "//site.example/path/to/document.md"
+
+
+def test_path_from_url(markdownurl_github_https_bare, markdownurl_github_https_raw, markdownurl_github_https_blob):
+    reference = "github://tests/data/hubspot-blog-post-original.md"
+    assert str(open_url(markdownurl_github_https_bare)) == reference
+    assert str(open_url(markdownurl_github_https_raw)) == reference
+    assert str(open_url(markdownurl_github_https_blob)) == reference

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,9 @@
+import json
+
+from hubspot.cms.blogs.blog_posts.rest import RESTResponse
+from urllib3 import HTTPResponse
+
+
+def mkresponse(data, status=200, reason="OK"):
+    body = json.dumps(data).encode("utf-8")
+    return RESTResponse(HTTPResponse(body=body, status=status, reason=reason))


### PR DESCRIPTION
## About

Currently, articles with image files can only be uploaded from the local filesystem. This patch intends to unlock the same features also for uploading directly from other source filesystems. For example, GitHub is the most valuable type here, assuming that most technical writings in Markdown format will originally be hosted there.

## Backlog

- [ ] Use [universal-pathlib](https://pypi.org/project/universal-pathlib/) instead of [pathlibfs](https://pypi.org/project/pathlibfs/).
- [ ] Add documentation.
