### PR TITLE
Adjust dependency specification for `click-aliases`, for Python 3.8 and 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dynamic = [
 dependencies = [
   "beautifulsoup4<5",
   "click<9",
-  "click-aliases<2",
+  "click-aliases<=1.0.5; python_version<'3.10'",
+  "click-aliases>=1.0.6,<2; python_version>='3.10'",
   "colorlog<7",
   "hubspot-api-client>=12,<13",
   "markdown<4",


### PR DESCRIPTION
## About

PyPI metadata shows `click-aliases` **1.0.5** and **1.0.6** **both** declare `requires_python >=3.7`, which is no longer true.

## References

- https://github.com/click-contrib/click-aliases/issues/32