### PR TITLE
Dependencies: Remove `setuptools` because `pkg_resources` was phased out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
   "markdown<4",
   "mkdocs-linkcheck<2",
   "requests<3",
-  "setuptools<81",
 ]
 
 optional-dependencies.develop = [


### PR DESCRIPTION
## About
`setuptools` was needed before when the project was still using `pkg_resources`.

## References
- GH-69
- GH-71