### PR TITLE
Dependencies: Adjust dependency specification for `click-aliases`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Adjusted dependency specification for `click-aliases`
 
 ## 2026-07-09 v0.1.3
 - Dependencies: Adjusted dependency specification for `click-aliases`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,7 @@ dynamic = [
 dependencies = [
   "beautifulsoup4<5",
   "click<9",
-  "click-aliases<=1.0.5; python_version<'3.10'",
-  "click-aliases>=1.0.6,<2; python_version>='3.10'",
+  "click-aliases!=1.0.6,<2",
   "colorlog<7",
   "hubspot-api-client>=12,<13",
   "markdown<4",


### PR DESCRIPTION
## About
click-aliases v1.0.7 has been released. Thanks, @rbonthond.

## References
- GH-77